### PR TITLE
Update Stockfish, Leela and OpenBLAS

### DIFF
--- a/io.github.benini.scid.yml
+++ b/io.github.benini.scid.yml
@@ -24,18 +24,18 @@ modules:
         env:
           ARCH: armv8
   build-commands:
-  - cp nn-ad9b42354671.nnue ./src
+  - cp nn-5af11540bbfe.nnue ./src
   - cd src; make -j build
   - mkdir -p /app/engines/stockfish
   - cp ./src/stockfish /app/engines/stockfish/
-  - cp ./nn-ad9b42354671.nnue /app/engines/stockfish/
+  - cp ./nn-5af11540bbfe.nnue /app/engines/stockfish/
   sources:
   - type: archive
-    url: https://github.com/official-stockfish/Stockfish/archive/refs/tags/sf_15.1.zip
-    sha256: 5174e4247f4c107648c9f7c906d5e9733abc61c6dae047be570cee2b930f0339
+    url: https://github.com/official-stockfish/Stockfish/releases/download/sf_16/stockfish-ubuntu-x86-64-modern.tar
+    sha256: dc94bdfbc0097a7606d3ed13b855cb03ee99184301b6fc8f8d85c68c4726bf8a
   - type: file
-    url: https://tests.stockfishchess.org/api/nn/nn-ad9b42354671.nnue
-    sha256: ad9b423546714137916bd38978af6fd68d7b8951bef25ff76bf43da72d6cb786
+    url: https://tests.stockfishchess.org/api/nn/nn-5af11540bbfe.nnue
+    sha256: 5af11540bbfefcb54e38c5dd000cab4b469dfa7599a1d55be5d2722c20a8929b
 
 - name: eigen # library for linear algebra, used for lc0
   buildsystem: cmake-ninja
@@ -58,8 +58,8 @@ modules:
   - rm /app/lib/*.a
   sources:
   - type: archive
-    url: https://github.com/xianyi/OpenBLAS/archive/refs/tags/v0.3.21.tar.gz
-    sha256: f36ba3d7a60e7c8bcc54cd9aaa9b1223dd42eaf02c811791c37e8ca707c241ca
+    url: https://github.com/xianyi/OpenBLAS/archive/refs/tags/v0.3.23.tar.gz
+    sha256: 5d9491d07168a5d00116cdc068a40022c3455bf9293c7cb86a65b1054d7e5114
 
 - name: lc0 # Lc0 engine, put into /app/engines/lc0
   buildsystem: meson
@@ -74,23 +74,24 @@ modules:
   - mv /app/bin/lc0 /app/engines/lc0/
   sources:
   - type: archive
-    url: https://github.com/LeelaChessZero/lc0/archive/refs/tags/v0.29.0.zip
-    sha256: 91b8c76db7009ae4592bd0e87d2f6fda01fc33c819264d107fd6fc16330cc868
+    url: https://github.com/LeelaChessZero/lc0/archive/refs/tags/v0.30.0.zip
+    sha256: 6cc94509214204933b21ded9b04545eaa7e21978cbfeea0be2927ba69cb012d8
   - type: archive
     dest: "./libs/lczero-common/"
     url: https://github.com/LeelaChessZero/lczero-common/archive/refs/heads/master.zip
-    sha256: 441eac56bf31aa966fd9baeecf2a71a2018475bd7c55310f61462fc7c8f2954c
+    sha256: 14aafc9d3ea1008da3a4ccddf0384ef2e40a90a4a30d61626b3a39bee6b2679e
 
-- name: nn # neural network T79, added to Lc0 (see https://lczero.org/play/networks/bestnets/)
+- name: nn # Recommended medium size network for GPU/CPU usage (see https://lczero.org/play/networks/bestnets/)
   buildsystem: simple
   build-commands:
   - mkdir -p /app/engines/lc0
-  - mv nn /app/engines/lc0/
+  - gzip -d nn.pb.gz 
+  - mv nn.pb /app/engines/lc0/
   sources:
   - type: file
-    dest-filename: nn
-    url: https://training.lczero.org/get_network?sha=195b450999e874d07aea2c09fd0db5eff9d4441ec1ad5a60a140fe8ea94c4f3a
-    sha256: ece2b5e06dc7c2121c31649be0effdd645f3df53bcf801623246d75494a866ad
+    dest-filename: nn.pb.gz
+    url: https://storage.lczero.org/files/networks-contrib/t1-512x15x8h-distilled-swa-3395000.pb.gz
+    sha256: 1fdb1519e5b02e03f1d9201ec8eb95f640e32cc6459a4f14c0eab6890dc097e8
 
 - name: tcl # latest stable tcl, required for scid
   sources:


### PR DESCRIPTION
Stockfish 16 has been released 3 weeks ago and Leela (and Open BLAS) has also been updated in the meantime, so I suggest the following updates:

Stockfish: 15.1 -> 16 (with fitting NN)
Leela: 0.29 -> 0.30 (with fitting NN)
OpenBLAS: 0.3.21 -> 0.3.23

I have already built the flatpak locally and checked that the engines work fine.