### PR TITLE
stockfish: Add correct .nnue for sf 18

### DIFF
--- a/io.github.benini.scid.yml
+++ b/io.github.benini.scid.yml
@@ -106,8 +106,8 @@ modules:
           url-template: https://github.com/official-stockfish/Stockfish/archive/sf_$version.tar.gz
       - type: file
         dest: src
-        url: https://tests.stockfishchess.org/api/nn/nn-1c0000000000.nnue
-        sha256: 1c0000000000a67d629999d932d0c373f7450ce43cd12d0562868f4eaf9ae2ad
+        url: https://tests.stockfishchess.org/api/nn/nn-c288c895ea92.nnue
+        sha256: c288c895ea924429ea9092e3f36b2b3c1f00f2a3a4c759ff7e57e79e3b43e4a7
       - type: file
         dest: src
         url: https://tests.stockfishchess.org/api/nn/nn-37f18f62d772.nnue


### PR DESCRIPTION
According to the [evaluate.h](https://github.com/official-stockfish/Stockfish/blob/sf_18/src/evaluate.h) file in Stockfish 18, the networks used are
```C++
#define EvalFileDefaultNameBig "nn-c288c895ea92.nnue"
#define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
```

In Stockfish 17.1 it used to be
```C++
#define EvalFileDefaultNameBig "nn-1c0000000000.nnue"
#define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
```

Stockfish won't run with the wrong network. This can be tested by running:

```term
flatpak run --command=sh io.github.benini.scid
/app/engines/stockfish
```

and then entering
```term
go infinite
```

Without this PR the following error message appears (instead of the analysis to start):
```
[📦 io.github.benini.scid io.github.benini.scid]$ /app/engines/stockfish
Stockfish 18 by the Stockfish developers (see AUTHORS file)
go infinite
info string Available processors: 0-7
info string Using 1 thread
info string ERROR: Network evaluation parameters compatible with the engine must be available.
info string ERROR: The network file nn-c288c895ea92.nnue was not loaded successfully.
info string ERROR: The UCI option EvalFile might need to specify the full path, including the directory name, to the network file.
info string ERROR: The default net can be downloaded from: https://tests.stockfishchess.org/api/nn/nn-c288c895ea92.nnue
info string ERROR: The engine will be terminated now.
```